### PR TITLE
fixed startup for PySide6 and PyQt5 and PyQt6

### DIFF
--- a/pylsl/examples/ReceiveAndPlot.py
+++ b/pylsl/examples/ReceiveAndPlot.py
@@ -188,7 +188,7 @@ def main():
 
     # Start Qt event loop unless running in interactive mode or using pyside.
     if (sys.flags.interactive != 1) or not hasattr(QtCore, "PYQT_VERSION"):
-        QtGui.QApplication.instance().exec_()
+        QtGui.QGuiApplication.instance().exec_()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It seems that a renaming from QApplication to QtGuiApplication is needed to get it running with PySide6, PyQt5, PyQt6