### PR TITLE
ENH: add __str__ and __repr__ for StreamInfo

### DIFF
--- a/src/pylsl/info.py
+++ b/src/pylsl/info.py
@@ -102,6 +102,16 @@ class StreamInfo:
         except Exception as e:
             print(f"StreamInfo deletion triggered error: {e}")
 
+    def __str__(self):
+        return (
+            f"<StreamInfo name='{self.name()}', type='{self.type()}', "
+            f"channels={self.channel_count()}, srate={self.nominal_srate()}, "
+            f"format={self.channel_format()}, source_id='{self.source_id()}'>"
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
     # === Core Information (assigned at construction) ===
 
     def name(self) -> str:


### PR DESCRIPTION
With this PR, Python users can get more meaningful information on `StreamInfo` objects at a glance. For example:

`<StreamInfo name='untitled', type='', channels=1, srate=0.0, format=1, source_id='2526407428071951342'>`